### PR TITLE
fix: resolve Ubuntu 24.04 Playwright compatibility and simplify CI

### DIFF
--- a/.github/workflows/feedxml-mx.yml
+++ b/.github/workflows/feedxml-mx.yml
@@ -72,20 +72,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements_2025.txt
+        pip install -r requirements_dev.txt
 
-    - name: Install Playwright browsers
+    - name: Install Playwright browsers (skip on Windows)
+      if: runner.os != 'Windows'
       run: |
-        playwright install --with-deps chromium
-      env:
-        PLAYWRIGHT_BROWSERS_PATH: 0
+        # Skip playwright installation for quality checks
+        # Only needed for actual feed processing
+        echo "Skipping Playwright for quality checks"
 
-    - name: Cache Playwright browsers
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('**/requirements_2025.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-
 
     - name: Lint with Ruff
       run: |
@@ -158,6 +153,11 @@ jobs:
 
     - name: Install and cache Playwright browsers
       run: |
+        # Fix for Ubuntu 24.04 compatibility
+        if [ "${{ runner.os }}" == "Linux" ]; then
+          sudo apt-get update
+          sudo apt-get install -y libasound2t64 || sudo apt-get install -y libasound2-dev
+        fi
         playwright install --with-deps chromium
 
     - name: Cache Playwright browsers

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,5 @@
+# Development dependencies for testing
+ruff>=0.1.0
+mypy>=1.0.0
+bandit>=1.7.0
+safety>=2.0.0


### PR DESCRIPTION
- Skip Playwright installation in quality checks (not needed)
- Separate dev dependencies from core requirements
- Remove unnecessary Playwright caching in tests
- Fix libasound2 virtual package issue on Ubuntu 24.04

The workflow now:
- Quality checks run without Playwright (faster)
- Only production feed processing installs Playwright
- Dev tools (ruff, mypy, bandit, safety) in separate file

🤖 Generated with [Claude Code](https://claude.ai/code)